### PR TITLE
Implement warehouse request availability and waybill flows

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -182,6 +182,7 @@ class Requisition(Base):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     branch_id = Column(String, ForeignKey("branches.id"), nullable=False)
     employee_id = Column(String, ForeignKey("employees.id"), nullable=True)
+    shipment_id = Column(String, ForeignKey("shipments.id"), nullable=True)
 
     status = Column(String, nullable=False, default="pending")
     comment = Column(Text, nullable=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.0
 pydantic==2.5.0
 python-multipart==0.0.6
 openpyxl==3.1.2
+reportlab==4.0.8

--- a/backend/services/stock.py
+++ b/backend/services/stock.py
@@ -11,40 +11,72 @@ class ItemType(str, Enum):
 
 
 def get_available_qty(
-    db: Session, branch_id: str, item_type: ItemType, item_id: str
+    db: Session, branch_id: Optional[str], item_type: ItemType, item_id: str
 ) -> Tuple[int, Optional[str]]:
     """Return available quantity and item name for given branch and item."""
     table = "medicines" if item_type == ItemType.medicine else "medical_devices"
-    row = db.execute(
-        text(
-            f"SELECT quantity, name FROM {table} WHERE id = :i AND branch_id = :b"
-        ),
-        {"i": item_id, "b": branch_id},
-    ).first()
+    if branch_id is None:
+        row = db.execute(
+            text(
+                f"SELECT quantity, name FROM {table} WHERE id = :i AND branch_id IS NULL"
+            ),
+            {"i": item_id},
+        ).first()
+    else:
+        row = db.execute(
+            text(
+                f"SELECT quantity, name FROM {table} WHERE id = :i AND branch_id = :b"
+            ),
+            {"i": item_id, "b": branch_id},
+        ).first()
     if not row:
         return 0, None
     return int(row[0]), row[1]
 
 
 def decrement_stock(
-    db: Session, branch_id: str, item_type: ItemType, item_id: str, qty: int
+    db: Session,
+    branch_id: Optional[str],
+    item_type: ItemType,
+    item_id: str,
+    qty: int,
 ) -> None:
     """Decrement stock atomically; raise ValueError if insufficient."""
     if qty <= 0:
         return
     table = "medicines" if item_type == ItemType.medicine else "medical_devices"
-    res = db.execute(
-        text(
-            f"""
-            UPDATE {table}
-               SET quantity = quantity - :q
-             WHERE id = :i AND branch_id = :b AND quantity >= :q
-            RETURNING quantity
-        """
-        ),
-        {"i": item_id, "b": branch_id, "q": qty},
-    ).first()
+    if branch_id is None:
+        res = db.execute(
+            text(
+                f"""
+                UPDATE {table}
+                   SET quantity = quantity - :q
+                 WHERE id = :i AND branch_id IS NULL AND quantity >= :q
+                RETURNING quantity
+            """
+            ),
+            {"i": item_id, "q": qty},
+        ).first()
+    else:
+        res = db.execute(
+            text(
+                f"""
+                UPDATE {table}
+                   SET quantity = quantity - :q
+                 WHERE id = :i AND branch_id = :b AND quantity >= :q
+                RETURNING quantity
+            """
+            ),
+            {"i": item_id, "b": branch_id, "q": qty},
+        ).first()
     if not res:
         raise ValueError(
             f"Not enough stock for {item_type}:{item_id}"
         )
+
+
+def get_main_available_qty(
+    db: Session, item_type: ItemType, item_id: str
+) -> Tuple[int, Optional[str]]:
+    """Convenience helper to get availability on the main warehouse (branch is NULL)."""
+    return get_available_qty(db, None, item_type, item_id)

--- a/backend/utils/waybill.py
+++ b/backend/utils/waybill.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from io import BytesIO
+from typing import List, Optional
+
+from zoneinfo import ZoneInfo
+
+from reportlab.graphics.barcode import qr
+from reportlab.graphics.shapes import Drawing
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+ALMATY_TZ = ZoneInfo("Asia/Almaty")
+
+
+def now_almaty() -> datetime:
+    return datetime.now(tz=ALMATY_TZ)
+
+
+def safe_filename(prefix: str, id_: str | int, ext: str = "pdf") -> str:
+    raw = f"{id_}"
+    sanitized = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in raw)
+    return f"{prefix}_{sanitized}.{ext}"
+
+
+@dataclass(slots=True)
+class WaybillItem:
+    name: str
+    item_type: str  # "medicine" | "medical_device"
+    quantity: int
+    unit: str = "шт."
+    note: Optional[str] = None
+
+
+@dataclass(slots=True)
+class WaybillData:
+    document_id: str
+    number: str
+    created_at: datetime
+    sender: str
+    receiver: str
+    items: List[WaybillItem] = field(default_factory=list)
+    comment: Optional[str] = None
+    prepared_by: Optional[str] = None
+    received_by: Optional[str] = None
+    company_name: Optional[str] = None
+    qr_value: Optional[str] = None
+
+
+_FONT_READY = False
+_FONT_MAIN = "Helvetica"
+_FONT_BOLD = "Helvetica-Bold"
+
+
+def _ensure_fonts() -> None:
+    global _FONT_READY, _FONT_MAIN, _FONT_BOLD
+    if _FONT_READY:
+        return
+
+    normal_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    bold_path = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+    try:
+        if os.path.exists(normal_path):
+            pdfmetrics.registerFont(TTFont("DejaVuSans", normal_path))
+            _FONT_MAIN = "DejaVuSans"
+        if os.path.exists(bold_path):
+            pdfmetrics.registerFont(TTFont("DejaVuSans-Bold", bold_path))
+            _FONT_BOLD = "DejaVuSans-Bold"
+    except Exception:
+        # If font registration fails, fall back to default fonts
+        _FONT_MAIN = "Helvetica"
+        _FONT_BOLD = "Helvetica-Bold"
+    finally:
+        _FONT_READY = True
+
+
+def _format_datetime(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=ZoneInfo("UTC")).astimezone(ALMATY_TZ)
+    return dt.astimezone(ALMATY_TZ)
+
+
+def _build_qr_drawing(value: str) -> Drawing:
+    widget = qr.QrCodeWidget(value)
+    bounds = widget.getBounds()
+    size = 32 * mm
+    width = bounds[2] - bounds[0]
+    height = bounds[3] - bounds[1]
+    drawing = Drawing(size, size)
+    transform = [size / width, 0, 0, size / height, 0, 0]
+    drawing.add(widget, transform=transform)
+    return drawing
+
+
+def render_waybill_pdf(data: WaybillData) -> bytes:
+    _ensure_fonts()
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        leftMargin=20 * mm,
+        rightMargin=20 * mm,
+        topMargin=22 * mm,
+        bottomMargin=20 * mm,
+        title=f"Waybill {data.number}",
+    )
+
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle(
+        name="WaybillTitle",
+        parent=styles["Title"],
+        fontName=_FONT_BOLD,
+        fontSize=16,
+        alignment=1,
+        spaceAfter=6,
+    )
+    subtitle_style = ParagraphStyle(
+        name="WaybillSubtitle",
+        parent=styles["Normal"],
+        fontName=_FONT_BOLD,
+        fontSize=11,
+        alignment=1,
+        spaceAfter=6,
+    )
+    meta_style = ParagraphStyle(
+        name="WaybillMeta",
+        parent=styles["Normal"],
+        fontName=_FONT_MAIN,
+        fontSize=10,
+        leading=14,
+        spaceAfter=4,
+    )
+    normal_style = ParagraphStyle(
+        name="WaybillNormal",
+        parent=styles["Normal"],
+        fontName=_FONT_MAIN,
+        fontSize=11,
+        leading=16,
+        spaceAfter=2,
+    )
+    small_style = ParagraphStyle(
+        name="WaybillSmall",
+        parent=styles["Normal"],
+        fontName=_FONT_MAIN,
+        fontSize=9,
+        leading=12,
+        spaceAfter=2,
+    )
+
+    story: List = []
+
+    if data.company_name:
+        story.append(Paragraph(data.company_name, subtitle_style))
+
+    story.append(Paragraph(f"НАКЛАДНАЯ № {data.number}", title_style))
+    local_dt = _format_datetime(data.created_at)
+    story.append(
+        Paragraph(
+            f"Дата: {local_dt.strftime('%d.%m.%Y %H:%M')} (Asia/Almaty)",
+            meta_style,
+        )
+    )
+    story.append(Spacer(1, 6))
+
+    story.append(Paragraph(f"Отправитель: {data.sender}", normal_style))
+    story.append(Paragraph(f"Получатель: {data.receiver}", normal_style))
+    story.append(Spacer(1, 10))
+
+    table_data = [
+        ["№", "Наименование", "Тип", "Кол-во", "Ед.", "Примечание"],
+    ]
+    for idx, item in enumerate(data.items, start=1):
+        type_label = "ЛС" if item.item_type == "medicine" else "ИМН"
+        table_data.append(
+            [
+                str(idx),
+                item.name,
+                type_label,
+                f"{item.quantity}",
+                item.unit or "шт.",
+                item.note or "",
+            ]
+        )
+
+    table = Table(
+        table_data,
+        colWidths=[12 * mm, 70 * mm, 20 * mm, 24 * mm, 20 * mm, 42 * mm],
+        repeatRows=1,
+    )
+    table.setStyle(
+        TableStyle(
+            [
+                ("FONT", (0, 0), (-1, 0), _FONT_BOLD),
+                ("FONTSIZE", (0, 0), (-1, 0), 10),
+                ("ALIGN", (0, 0), (0, -1), "CENTER"),
+                ("ALIGN", (2, 1), (4, -1), "CENTER"),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.whitesmoke]),
+                ("FONT", (0, 1), (-1, -1), _FONT_MAIN),
+            ]
+        )
+    )
+    story.append(table)
+
+    total_qty = sum(item.quantity for item in data.items)
+    story.append(Spacer(1, 8))
+    story.append(
+        Paragraph(
+            f"Итого строк: {len(data.items)}  |  Общее количество: {total_qty}",
+            normal_style,
+        )
+    )
+
+    if data.comment:
+        story.append(Spacer(1, 6))
+        story.append(Paragraph("Комментарий:", small_style))
+        story.append(
+            Paragraph(data.comment.replace("\n", "<br/>"), small_style)
+        )
+
+    story.append(Spacer(1, 14))
+
+    signatures = Table(
+        [
+            ["Отпустил", "", "Принял", ""],
+            ["____________________", "", "____________________", ""],
+            [data.prepared_by or "", "", data.received_by or "", ""],
+        ],
+        colWidths=[45 * mm, 15 * mm, 45 * mm, 15 * mm],
+    )
+    signatures.setStyle(
+        TableStyle(
+            [
+                ("FONT", (0, 0), (-1, 0), _FONT_BOLD),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("FONT", (0, 1), (-1, 2), _FONT_MAIN),
+                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("BOTTOMPADDING", (0, 0), (-1, 0), 6),
+            ]
+        )
+    )
+    story.append(signatures)
+
+    if data.qr_value:
+        story.append(Spacer(1, 12))
+        story.append(Paragraph("QR-код для проверки:", small_style))
+        story.append(_build_qr_drawing(data.qr_value))
+
+    doc.build(story)
+    return buffer.getvalue()

--- a/src/pages/admin/Requisitions.tsx
+++ b/src/pages/admin/Requisitions.tsx
@@ -20,61 +20,74 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Loader2, Check, X } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Loader2, FileDown, Printer, AlertTriangle, CheckCircle2 } from 'lucide-react';
 
 type RequisitionItem = {
-  type: string;
+  type: 'medicine' | 'medical_device';
   id: string;
   name: string;
   quantity: number;
 };
 
-type Requisition = {
+type AvailabilityItem = {
+  item_type: 'medicine' | 'medical_device';
+  item_id: string;
+  name: string;
+  requested_qty: number;
+  available_qty: number;
+  shortage: number;
+};
+
+type WarehouseRequest = {
   id: string;
   branch_id: string;
+  branch_name?: string | null;
   employee_id?: string | null;
-  status: 'pending' | 'approved' | 'rejected';
+  status: string;
   comment?: string | null;
   processed_by?: string | null;
   processed_at?: string | null;
-  created_at: string;
+  created_at?: string | null;
+  shipment_id?: string | null;
   items: RequisitionItem[];
+  availability: AvailabilityItem[];
+  shortage_total?: number;
+  can_fulfill?: boolean;
 };
 
-const STATUS_LABELS: Record<Requisition['status'], string> = {
+const STATUS_LABELS: Record<string, string> = {
   pending: 'В ожидании',
-  approved: 'Принята',
+  approved: 'Одобрена',
+  accepted: 'Отгружена',
   rejected: 'Отклонена',
 };
 
-const STATUS_VARIANTS: Record<Requisition['status'], 'secondary' | 'default' | 'destructive'> = {
+const STATUS_VARIANTS: Record<string, 'secondary' | 'default' | 'destructive'> = {
   pending: 'secondary',
   approved: 'default',
+  accepted: 'default',
   rejected: 'destructive',
+};
+
+const TYPE_LABEL: Record<'medicine' | 'medical_device', string> = {
+  medicine: 'Лекарство',
+  medical_device: 'ИМН',
 };
 
 const AdminRequisitions: React.FC = () => {
   const [branches, setBranches] = useState<any[]>([]);
-  const [requisitions, setRequisitions] = useState<Requisition[]>([]);
+  const [requisitions, setRequisitions] = useState<WarehouseRequest[]>([]);
   const [loadingList, setLoadingList] = useState(true);
-  const [processingStatus, setProcessingStatus] = useState(false);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailLoading, setDetailLoading] = useState(false);
-  const [selectedRequisition, setSelectedRequisition] = useState<Requisition | null>(null);
-  const [rejectReason, setRejectReason] = useState('');
+  const [selectedRequest, setSelectedRequest] = useState<WarehouseRequest | null>(null);
+  const [accepting, setAccepting] = useState(false);
+  const [acceptComment, setAcceptComment] = useState('');
+  const [lastShipmentId, setLastShipmentId] = useState<string | null>(null);
 
-  const [filters, setFilters] = useState({
-    branch: 'ALL',
-    status: 'ALL',
-    dateFrom: '',
-    dateTo: '',
-  });
+  const [filters, setFilters] = useState({ branch: 'ALL', status: 'ALL', dateFrom: '', dateTo: '' });
 
   const branchMap = useMemo(() => {
     const map: Record<string, string> = {};
@@ -86,14 +99,45 @@ const AdminRequisitions: React.FC = () => {
     return map;
   }, [branches]);
 
-  const formatDate = (iso: string | null | undefined) => {
-    if (!iso) return '';
-    const date = new Date(iso);
-    return date.toLocaleString('ru-RU');
-  };
+  const getShortageTotal = useCallback((req: WarehouseRequest) => {
+    if (typeof req.shortage_total === 'number') {
+      return req.shortage_total;
+    }
+    return Array.isArray(req.availability)
+      ? req.availability.reduce((sum, item) => sum + (item.shortage ?? 0), 0)
+      : 0;
+  }, []);
 
-  const summarizeItems = (items: RequisitionItem[]) =>
-    items.map((item) => `${item.name} — ${item.quantity} шт.`).join('; ');
+  const hasEnoughStock = useCallback(
+    (req: WarehouseRequest) => {
+      if (typeof req.can_fulfill === 'boolean') {
+        return req.can_fulfill;
+      }
+      return getShortageTotal(req) === 0;
+    },
+    [getShortageTotal],
+  );
+
+  const summarizeItems = useCallback((req: WarehouseRequest) => {
+    const items = Array.isArray(req.items) ? req.items : [];
+    if (items.length === 0) return 'Позиции не указаны';
+    return items.map((item) => `${item.name} — ${item.quantity} шт.`).join('; ');
+  }, []);
+
+  const parseErrorMessage = useCallback((error: unknown) => {
+    if (error instanceof Error) {
+      try {
+        const parsed = JSON.parse(error.message);
+        if (parsed?.message) {
+          return parsed.message as string;
+        }
+      } catch {
+        /* ignore */
+      }
+      return error.message;
+    }
+    return 'Неизвестная ошибка';
+  }, []);
 
   const loadBranches = useCallback(async () => {
     try {
@@ -114,14 +158,14 @@ const AdminRequisitions: React.FC = () => {
     }
   }, []);
 
-  const loadRequisitions = useCallback(async () => {
+  const loadRequests = useCallback(async () => {
     setLoadingList(true);
     try {
       const params: Record<string, string> = {};
-      if (filters.branch !== 'ALL' && filters.branch) {
+      if (filters.branch && filters.branch !== 'ALL') {
         params.branch_id = filters.branch;
       }
-      if (filters.status !== 'ALL' && filters.status) {
+      if (filters.status && filters.status !== 'ALL') {
         params.status = filters.status;
       }
       if (filters.dateFrom) {
@@ -131,127 +175,216 @@ const AdminRequisitions: React.FC = () => {
         params.date_to = filters.dateTo;
       }
 
-      const res = await apiService.getAdminRequisitions(params);
-      if ((res as any)?.error) {
-        throw new Error((res as any).error);
+      const res = await apiService.getWarehouseRequests(params);
+      if (res.error) {
+        throw new Error(res.error);
       }
       const data = Array.isArray(res?.data?.data)
-        ? (res?.data?.data as Requisition[])
+        ? (res.data.data as WarehouseRequest[])
         : Array.isArray(res?.data)
-          ? (res?.data as Requisition[])
+          ? (res.data as WarehouseRequest[])
           : [];
-      setRequisitions(data || []);
+      setRequisitions(data ?? []);
     } catch (error) {
-      console.error('Failed to load requisitions', error);
+      console.error('Failed to load requests', error);
       toast({
         title: 'Ошибка',
-        description: error instanceof Error ? error.message : 'Не удалось загрузить заявки',
+        description: parseErrorMessage(error),
         variant: 'destructive',
       });
     } finally {
       setLoadingList(false);
     }
-  }, [filters.branch, filters.dateFrom, filters.dateTo, filters.status]);
-
-  const refreshSelected = useCallback(
-    (updated?: Requisition | null) => {
-      if (updated) {
-        setSelectedRequisition(updated);
-      } else if (selectedRequisition) {
-        const fresh = requisitions.find((req) => req.id === selectedRequisition.id);
-        if (fresh) {
-          setSelectedRequisition(fresh);
-        }
-      }
-    },
-    [requisitions, selectedRequisition],
-  );
+  }, [filters.branch, filters.dateFrom, filters.dateTo, filters.status, parseErrorMessage]);
 
   useEffect(() => {
     loadBranches();
   }, [loadBranches]);
 
   useEffect(() => {
-    loadRequisitions();
-  }, [loadRequisitions]);
+    loadRequests();
+  }, [loadRequests]);
 
-  const openDetail = async (requisition: Requisition) => {
-    setSelectedRequisition(requisition);
-    setRejectReason('');
-    setDetailOpen(true);
-    setDetailLoading(true);
-    try {
-      const res = await apiService.getAdminRequisitionById(requisition.id);
-      if ((res as any)?.error) {
-        throw new Error((res as any).error);
-      }
-      const data = (res?.data?.data ?? res?.data) as Requisition | undefined;
-      if (data) {
-        setSelectedRequisition(data);
-      }
-    } catch (error) {
-      console.error('Failed to load requisition detail', error);
-      toast({
-        title: 'Ошибка',
-        description: 'Не удалось загрузить детали заявки',
-        variant: 'destructive',
-      });
-    } finally {
-      setDetailLoading(false);
-    }
-  };
+  const formatDate = useCallback((iso?: string | null) => {
+    if (!iso) return '';
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleString('ru-RU');
+  }, []);
 
-  const closeDetail = () => {
+  const openDetail = useCallback(
+    async (request: WarehouseRequest) => {
+      setSelectedRequest(request);
+      setLastShipmentId(request.shipment_id ?? null);
+      setAcceptComment('');
+      setDetailOpen(true);
+      setDetailLoading(true);
+      try {
+        const res = await apiService.getWarehouseRequestById(request.id);
+        if (res.error) {
+          throw new Error(res.error);
+        }
+        const data = (res?.data?.data ?? res?.data) as WarehouseRequest | undefined;
+        if (data) {
+          setSelectedRequest(data);
+          setLastShipmentId(data.shipment_id ?? null);
+        }
+      } catch (error) {
+        console.error('Failed to load request detail', error);
+        toast({
+          title: 'Ошибка',
+          description: parseErrorMessage(error),
+          variant: 'destructive',
+        });
+      } finally {
+        setDetailLoading(false);
+      }
+    },
+    [parseErrorMessage],
+  );
+
+  const closeDetail = useCallback(() => {
     setDetailOpen(false);
-    setSelectedRequisition(null);
-    setRejectReason('');
-  };
+    setSelectedRequest(null);
+    setAcceptComment('');
+    setLastShipmentId(null);
+  }, []);
 
-  const handleStatusChange = async (
-    id: string,
-    status: 'approved' | 'rejected',
-    reason?: string,
-  ) => {
-    setProcessingStatus(true);
+  const refreshDetail = useCallback(async (id: string) => {
+    const detail = await apiService.getWarehouseRequestById(id);
+    if (!detail.error) {
+      const data = (detail.data?.data ?? detail.data) as WarehouseRequest | undefined;
+      if (data) {
+        setSelectedRequest(data);
+        setLastShipmentId(data.shipment_id ?? null);
+      }
+    }
+  }, []);
+
+  const handleAccept = useCallback(async () => {
+    if (!selectedRequest) return;
+
+    const shortage = getShortageTotal(selectedRequest);
+    if (shortage > 0 || selectedRequest.status === 'accepted') {
+      return;
+    }
+
+    setAccepting(true);
     try {
-      const payload: { status: 'approved' | 'rejected'; reason?: string } = { status };
-      if (reason) {
-        payload.reason = reason;
+      const comment = acceptComment.trim();
+      const res = await apiService.acceptWarehouseRequest(
+        selectedRequest.id,
+        comment ? { comment } : undefined,
+      );
+      if (res.error) {
+        throw new Error(res.error);
       }
-      const res = await apiService.updateAdminRequisitionStatus(id, payload);
-      if ((res as any)?.error) {
-        throw new Error((res as any).error);
-      }
-      const data = (res?.data?.data ?? res?.data) as Requisition | undefined;
+      const payload = res.data as { shipment_id?: string };
+      const shipmentId = payload?.shipment_id ?? null;
+      setLastShipmentId(shipmentId);
       toast({
-        title: status === 'approved' ? 'Заявка принята' : 'Заявка отклонена',
-        description:
-          status === 'approved'
-            ? 'Заявка успешно утверждена'
-            : 'Заявка отклонена. Филиал будет уведомлён',
+        title: 'Отгрузка создана',
+        description: 'Заявка принята и отгрузка сформирована',
       });
-      await loadRequisitions();
-      refreshSelected(data ?? null);
-      if (status === 'approved') {
-        setRejectReason('');
-      }
+      setAcceptComment('');
+      await loadRequests();
+      await refreshDetail(selectedRequest.id);
     } catch (error) {
-      console.error('Failed to change status', error);
+      console.error('Failed to accept request', error);
       toast({
         title: 'Ошибка',
-        description: error instanceof Error ? error.message : 'Не удалось изменить статус заявки',
+        description: parseErrorMessage(error),
         variant: 'destructive',
       });
+      await refreshDetail(selectedRequest.id);
     } finally {
-      setProcessingStatus(false);
+      setAccepting(false);
     }
-  };
+  }, [acceptComment, getShortageTotal, loadRequests, parseErrorMessage, refreshDetail, selectedRequest]);
+
+  const downloadShipmentWaybill = useCallback(
+    async (shipmentId: string) => {
+      try {
+        const response = await apiService.getShipmentWaybill(shipmentId);
+        const blob = await response.blob();
+        const disposition = response.headers.get('content-disposition');
+        let filename = `waybill_${shipmentId}.pdf`;
+        if (disposition) {
+          const match = /filename="?([^";]+)"?/i.exec(disposition);
+          if (match?.[1]) {
+            filename = match[1];
+          }
+        }
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(url), 2000);
+      } catch (error) {
+        console.error('Failed to download waybill', error);
+        toast({
+          title: 'Ошибка',
+          description: parseErrorMessage(error),
+          variant: 'destructive',
+        });
+      }
+    },
+    [parseErrorMessage],
+  );
+
+  const printShipmentWaybill = useCallback(
+    async (shipmentId: string) => {
+      try {
+        const response = await apiService.getShipmentWaybill(shipmentId);
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const cleanup = () => {
+          setTimeout(() => URL.revokeObjectURL(url), 4000);
+        };
+        const win = window.open(url);
+        if (win) {
+          win.onload = () => {
+            win.focus();
+            win.print();
+            cleanup();
+          };
+        } else {
+          const iframe = document.createElement('iframe');
+          iframe.style.position = 'fixed';
+          iframe.style.width = '0';
+          iframe.style.height = '0';
+          iframe.style.border = '0';
+          iframe.src = url;
+          document.body.appendChild(iframe);
+          iframe.onload = () => {
+            iframe.contentWindow?.focus();
+            iframe.contentWindow?.print();
+            cleanup();
+            setTimeout(() => iframe.remove(), 4000);
+          };
+        }
+      } catch (error) {
+        console.error('Failed to print waybill', error);
+        toast({
+          title: 'Ошибка',
+          description: parseErrorMessage(error),
+          variant: 'destructive',
+        });
+      }
+    },
+    [parseErrorMessage],
+  );
 
   return (
     <div className="space-y-8">
       <div>
         <h1 className="text-3xl font-bold">Заявки филиалов</h1>
-        <p className="text-muted-foreground">Просматривайте и обрабатывайте заявки от филиалов</p>
+        <p className="text-muted-foreground">
+          Проверяйте доступность позиций на главном складе и создавайте отгрузки по готовым заявкам
+        </p>
       </div>
 
       <section className="bg-white rounded-lg shadow p-6 space-y-4">
@@ -289,8 +422,9 @@ const AdminRequisitions: React.FC = () => {
               <SelectContent>
                 <SelectItem value="ALL">Все</SelectItem>
                 <SelectItem value="pending">В ожидании</SelectItem>
-                <SelectItem value="approved">Принятые</SelectItem>
-                <SelectItem value="rejected">Отклонённые</SelectItem>
+                <SelectItem value="accepted">Отгружена</SelectItem>
+                <SelectItem value="approved">Одобрена</SelectItem>
+                <SelectItem value="rejected">Отклонена</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -326,6 +460,7 @@ const AdminRequisitions: React.FC = () => {
               <TableHead>Дата</TableHead>
               <TableHead>Филиал</TableHead>
               <TableHead>Статус</TableHead>
+              <TableHead>Наличие</TableHead>
               <TableHead>Позиции</TableHead>
               <TableHead className="text-right">Действия</TableHead>
             </TableRow>
@@ -333,63 +468,57 @@ const AdminRequisitions: React.FC = () => {
           <TableBody>
             {loadingList ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center py-8">
+                <TableCell colSpan={6} className="text-center py-8">
                   <Loader2 className="h-5 w-5 animate-spin inline-block mr-2" />
                   Загрузка заявок...
                 </TableCell>
               </TableRow>
             ) : requisitions.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
                   Заявок не найдено
                 </TableCell>
               </TableRow>
             ) : (
-              requisitions.map((requisition) => (
-                <TableRow key={requisition.id}>
-                  <TableCell className="whitespace-nowrap">{formatDate(requisition.created_at)}</TableCell>
-                  <TableCell>{branchMap[requisition.branch_id] ?? requisition.branch_id}</TableCell>
-                  <TableCell>
-                    <Badge variant={STATUS_VARIANTS[requisition.status]}>
-                      {STATUS_LABELS[requisition.status]}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="max-w-xl truncate">
-                    {summarizeItems(requisition.items)}
-                  </TableCell>
-                  <TableCell className="text-right space-x-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => openDetail(requisition)}
-                    >
-                      Подробнее
-                    </Button>
-                    {requisition.status === 'pending' && (
-                      <>
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          size="sm"
-                          disabled={processingStatus}
-                          onClick={() => handleStatusChange(requisition.id, 'approved')}
-                        >
-                          <Check className="h-4 w-4 mr-1" /> Принять
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="destructive"
-                          size="sm"
-                          onClick={() => openDetail(requisition)}
-                        >
-                          <X className="h-4 w-4 mr-1" /> Отклонить
-                        </Button>
-                      </>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))
+              requisitions.map((req) => {
+                const branchName = req.branch_name ?? branchMap[req.branch_id] ?? req.branch_id;
+                const statusLabel = STATUS_LABELS[req.status] ?? req.status;
+                const statusVariant = STATUS_VARIANTS[req.status] ?? 'secondary';
+                const shortage = getShortageTotal(req);
+                const enough = hasEnoughStock(req);
+
+                return (
+                  <TableRow key={req.id}>
+                    <TableCell className="whitespace-nowrap">{formatDate(req.created_at)}</TableCell>
+                    <TableCell>{branchName}</TableCell>
+                    <TableCell>
+                      <Badge variant={statusVariant}>{statusLabel}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {enough ? (
+                        <Badge className="bg-emerald-100 text-emerald-700 border-transparent">
+                          Хватает
+                        </Badge>
+                      ) : (
+                        <Badge className="bg-red-100 text-red-700 border-transparent">
+                          Недостаточно: -{shortage}
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="max-w-xl truncate">{summarizeItems(req)}</TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => openDetail(req)}
+                      >
+                        Подробнее
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
             )}
           </TableBody>
         </Table>
@@ -399,7 +528,7 @@ const AdminRequisitions: React.FC = () => {
         <DialogContent className="max-w-3xl">
           <DialogHeader>
             <DialogTitle>
-              {selectedRequisition ? `Заявка #${selectedRequisition.id.slice(0, 8)}` : 'Заявка'}
+              {selectedRequest ? `Заявка #${selectedRequest.id.slice(0, 8)}` : 'Заявка'}
             </DialogTitle>
           </DialogHeader>
 
@@ -407,97 +536,151 @@ const AdminRequisitions: React.FC = () => {
             <div className="py-10 text-center text-muted-foreground">
               <Loader2 className="h-5 w-5 animate-spin inline-block mr-2" /> Загрузка...
             </div>
-          ) : selectedRequisition ? (
+          ) : selectedRequest ? (
             <div className="space-y-6">
               <div className="flex flex-wrap items-center gap-3">
-                <Badge variant={STATUS_VARIANTS[selectedRequisition.status]}>
-                  {STATUS_LABELS[selectedRequisition.status]}
+                <Badge variant={STATUS_VARIANTS[selectedRequest.status] ?? 'secondary'}>
+                  {STATUS_LABELS[selectedRequest.status] ?? selectedRequest.status}
                 </Badge>
                 <span className="text-sm text-muted-foreground">
-                  Филиал: {branchMap[selectedRequisition.branch_id] ?? selectedRequisition.branch_id}
+                  Филиал:{' '}
+                  {selectedRequest.branch_name ??
+                    branchMap[selectedRequest.branch_id] ??
+                    selectedRequest.branch_id}
                 </span>
                 <span className="text-sm text-muted-foreground">
-                  Создана: {formatDate(selectedRequisition.created_at)}
+                  Создана: {formatDate(selectedRequest.created_at)}
                 </span>
+                {selectedRequest.processed_at && (
+                  <span className="text-sm text-muted-foreground">
+                    Обработана: {formatDate(selectedRequest.processed_at)}
+                  </span>
+                )}
               </div>
+
+              {!hasEnoughStock(selectedRequest) && (
+                <Alert variant="destructive">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTitle>Недостаточно остатков</AlertTitle>
+                  <AlertDescription>
+                    Суммарный дефицит по заявке: -{getShortageTotal(selectedRequest)} шт.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {(selectedRequest.status === 'accepted' || lastShipmentId) && (
+                <Alert className="bg-emerald-50 border-emerald-200 text-emerald-900">
+                  <CheckCircle2 className="h-4 w-4" />
+                  <AlertTitle>Отгрузка создана</AlertTitle>
+                  <AlertDescription>
+                    Номер отгрузки: {(selectedRequest.shipment_id ?? lastShipmentId ?? '').slice(0, 8)}
+                  </AlertDescription>
+                </Alert>
+              )}
 
               <div className="border rounded-lg">
                 <Table>
                   <TableHeader>
                     <TableRow>
                       <TableHead>Позиция</TableHead>
-                      <TableHead className="w-32 text-right">Количество</TableHead>
+                      <TableHead className="text-right">Запрошено / Доступно</TableHead>
+                      <TableHead className="text-right">Дефицит</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {selectedRequisition.items.map((item) => (
-                      <TableRow key={`${item.type}-${item.id}`}>
+                    {(selectedRequest.availability ?? []).map((item) => (
+                      <TableRow key={`${item.item_type}-${item.item_id}`}>
                         <TableCell>
                           <div className="font-medium">{item.name}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {item.type === 'medicine' ? 'Лекарство' : 'ИМН'}
-                          </div>
+                          <div className="text-xs text-muted-foreground">{TYPE_LABEL[item.item_type]}</div>
                         </TableCell>
-                        <TableCell className="text-right">{item.quantity} шт.</TableCell>
+                        <TableCell className="text-right">
+                          <span className="font-medium">{item.requested_qty}</span>
+                          <span className="text-muted-foreground"> / </span>
+                          <span className="font-medium">{item.available_qty}</span>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {item.shortage > 0 ? (
+                            <span className="text-destructive font-medium">
+                              -{item.shortage}
+                              <span className="ml-1 text-xs font-normal">Не хватает</span>
+                            </span>
+                          ) : (
+                            <span className="text-emerald-600 font-medium">0</span>
+                          )}
+                        </TableCell>
                       </TableRow>
                     ))}
                   </TableBody>
                 </Table>
               </div>
 
-              {selectedRequisition.comment && (
+              {selectedRequest.comment && (
                 <div>
                   <h3 className="text-sm font-semibold mb-1">Комментарий</h3>
                   <p className="text-sm text-muted-foreground whitespace-pre-wrap">
-                    {selectedRequisition.comment}
+                    {selectedRequest.comment}
                   </p>
                 </div>
               )}
 
-              {selectedRequisition.processed_at && (
-                <div className="text-sm text-muted-foreground">
-                  Обработано: {formatDate(selectedRequisition.processed_at)} (пользователь {selectedRequisition.processed_by})
+              {selectedRequest.status !== 'accepted' && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-gray-700">
+                    Комментарий к отгрузке (опционально)
+                  </label>
+                  <Textarea
+                    placeholder="Укажите дополнительные инструкции для отгрузки"
+                    value={acceptComment}
+                    onChange={(event) => setAcceptComment(event.target.value)}
+                  />
                 </div>
               )}
 
-              {selectedRequisition.status === 'pending' && (
-                <div className="space-y-3">
-                  <div>
-                    <h3 className="text-sm font-semibold mb-1">Причина отклонения</h3>
-                    <Textarea
-                      placeholder="Укажите причину, если отклоняете заявку"
-                      value={rejectReason}
-                      onChange={(event) => setRejectReason(event.target.value)}
-                    />
-                  </div>
-                  <div className="flex flex-wrap gap-3 justify-end">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      disabled={processingStatus}
-                      onClick={() => handleStatusChange(selectedRequisition.id, 'approved')}
-                    >
-                      {processingStatus ? (
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      ) : (
-                        <Check className="h-4 w-4 mr-2" />
-                      )}
-                      Принять
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      disabled={processingStatus}
-                      onClick={() => handleStatusChange(selectedRequisition.id, 'rejected', rejectReason.trim() || undefined)}
-                    >
-                      {processingStatus ? (
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      ) : (
-                        <X className="h-4 w-4 mr-2" />
-                      )}
-                      Отклонить
-                    </Button>
-                  </div>
+              <div className="flex flex-wrap gap-3 justify-end">
+                <Button type="button" variant="secondary" onClick={closeDetail} disabled={accepting}>
+                  Закрыть
+                </Button>
+                <Button
+                  type="button"
+                  className="gap-2"
+                  onClick={handleAccept}
+                  disabled={
+                    accepting ||
+                    !hasEnoughStock(selectedRequest) ||
+                    selectedRequest.status === 'accepted'
+                  }
+                  title={
+                    !hasEnoughStock(selectedRequest)
+                      ? 'Недостаточно остатков для отгрузки'
+                      : selectedRequest.status === 'accepted'
+                        ? 'Отгрузка уже создана'
+                        : undefined
+                  }
+                >
+                  {accepting && <Loader2 className="h-4 w-4 animate-spin" />}
+                  Принять и отгрузить
+                </Button>
+              </div>
+
+              {selectedRequest.shipment_id && (
+                <div className="flex flex-wrap gap-3 border-t pt-4">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => downloadShipmentWaybill(selectedRequest.shipment_id!)}
+                  >
+                    <FileDown className="h-4 w-4 mr-2" />
+                    Скачать накладную (PDF)
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => printShipmentWaybill(selectedRequest.shipment_id!)}
+                  >
+                    <Printer className="h-4 w-4 mr-2" />
+                    Печать
+                  </Button>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- add main-warehouse availability computations, acceptance API, and PDF waybill endpoints
- implement reportlab-based waybill rendering utilities and extend stock helpers for branchless lookups
- refresh admin requests UI with availability indicators, guarded acceptance, and shipment waybill actions plus shipment list download/print buttons

## Testing
- npm run build
- pytest tests/test_dispensing.py *(fails: ModuleNotFoundError for reportlab; package cannot be fetched behind the sandbox proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e63bda3d5c8328a459e6dac78fd484