### PR TITLE
Fix waybill QR scaling and remove shipping controls

### DIFF
--- a/backend/utils/waybill.py
+++ b/backend/utils/waybill.py
@@ -58,13 +58,22 @@ class WaybillData:
 
 
 def _build_qr_drawing(value: str, size: int = 80) -> Drawing:
-    code = qr.QrCodeWidget(value)
+    """
+    Return a Drawing with a QR for 'value' scaled to 'size' x 'size'.
+    We scale/translate on the Drawing, not on QrCodeWidget.
+    """
+    code = qr.QrCodeWidget(value or "")
     x1, y1, x2, y2 = code.getBounds()
-    width = x2 - x1
-    height = y2 - y1
-    scale = float(size) / float(max(width, height) or 1)
-    d = Drawing(size, size)
-    code.transform = (scale, 0, 0, scale, 0, 0)
+    w, h = (x2 - x1), (y2 - y1)
+    if w <= 0 or h <= 0:
+        w = h = 1.0
+    scale = float(size) / max(w, h)
+
+    # Move origin so QR’s lower-left corner is at (0,0), then scale to target size.
+    # transform = [sx, 0, 0, sy, tx, ty]
+    tx = -x1 * scale
+    ty = -y1 * scale
+    d = Drawing(size, size, transform=[scale, 0, 0, scale, tx, ty])
     d.add(code)
     return d
 

--- a/src/pages/admin/Shipments.tsx
+++ b/src/pages/admin/Shipments.tsx
@@ -325,35 +325,6 @@ const Shipments = () => {
     }
   };
 
-  const onShip = async (shipment: any) => {
-    try {
-      setBusy(true);
-      setBusyShipmentId(shipment.id);
-      await apiService.shipShipment(shipment.id);
-      toast({ title: 'Отгружено' });
-      await refetch();
-    } catch (error: any) {
-      const detail = error?.response?.data?.detail ?? error?.response?.data;
-      const message = detail?.message ?? error?.message ?? 'Не удалось отгрузить';
-      const insufficient = detail?.insufficient;
-      if (Array.isArray(insufficient) && insufficient.length) {
-        const text = insufficient
-          .map((item: any) => `${item.name}: нужно ${item.requested}, есть ${item.available}`)
-          .join('\n');
-        toast({
-          title: 'Недостаточно остатков',
-          description: <div className="whitespace-pre-line">{text}</div>,
-          variant: 'destructive',
-        });
-      } else {
-        toast({ title: 'Ошибка', description: message, variant: 'destructive' });
-      }
-    } finally {
-      setBusy(false);
-      setBusyShipmentId(null);
-    }
-  };
-
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'pending':
@@ -693,16 +664,6 @@ const Shipments = () => {
                     >
                       <CheckCircle className="h-4 w-4 mr-1" />
                       Принять
-                    </Button>
-                  )}
-                  {shipment.status === 'accepted' && (
-                    <Button
-                      size="sm"
-                      onClick={() => onShip(shipment)}
-                      disabled={busy && busyShipmentId === shipment.id}
-                    >
-                      <Truck className="h-4 w-4 mr-1" />
-                      Отгрузить
                     </Button>
                   )}
                   <Button


### PR DESCRIPTION
## Summary
- fix the waybill QR renderer to scale via the Drawing transform and prevent ReportLab errors
- remove the ship action from the admin shipments list so only accept/download/print remain
- simplify warehouse request handling to a single "Принять" action and update related messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e791e1770c83289e641a5e7fda4e7d