### PR TITLE
Add admin tracking for payroll, expenses, and reports

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -157,7 +157,7 @@ class Shipment(Base):
 
 class ShipmentItem(Base):
     __tablename__ = "shipment_items"
-    
+
     id = Column(String, primary_key=True)
     shipment_id = Column(String, ForeignKey("shipments.id"), nullable=False)
     item_type = Column(String, nullable=False)  # medicine or device
@@ -207,6 +207,32 @@ class RequisitionItem(Base):
     quantity = Column(Integer, nullable=False)
 
     requisition = relationship("Requisition", back_populates="items")
+
+
+# --- Tracking models: payroll & expenses ---
+class PayrollEntry(Base):
+    __tablename__ = "payroll_entries"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    first_name = Column(String, nullable=False)
+    last_name = Column(String, nullable=False)
+    role = Column(String, nullable=False)
+    branch_id = Column(String, ForeignKey("branches.id"), nullable=True)
+    amount = Column(Float, nullable=False)
+    date = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class ExpenseEntry(Base):
+    __tablename__ = "expense_entries"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    title = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    branch_id = Column(String, ForeignKey("branches.id"), nullable=True)
+    amount = Column(Float, nullable=False)
+    date = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=datetime.utcnow)
 
 # Database dependency
 def get_db():

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,9 @@ import Analytics from "@/pages/admin/Analytics";
 import MedicalDevicesCategories from "@/pages/admin/MedicalDevicesCategories";
 import MedicineCategories from "@/pages/admin/MedicineCategories";
 import AdminRequisitions from "@/pages/admin/Requisitions";
+import AdminPayroll from "@/pages/admin/tracking/Payroll";
+import AdminExpenses from "@/pages/admin/tracking/Expenses";
+import AdminTrackingReport from "@/pages/admin/tracking/Report";
 
 // Branch pages
 import BranchDashboard from "@/pages/branch/BranchDashboard";
@@ -94,6 +97,9 @@ const App = () => {
             <Route path="/admin/medical-devices-categories" element={<ProtectedRoute requiredRole="admin"><MedicalDevicesCategories /></ProtectedRoute>} />
             <Route path="/admin/shipments" element={<ProtectedRoute requiredRole="admin"><Shipments /></ProtectedRoute>} />
             <Route path="/admin/requisitions" element={<ProtectedRoute requiredRole="admin"><AdminRequisitions /></ProtectedRoute>} />
+            <Route path="/admin/tracking/payroll" element={<ProtectedRoute requiredRole="admin"><AdminPayroll /></ProtectedRoute>} />
+            <Route path="/admin/tracking/expenses" element={<ProtectedRoute requiredRole="admin"><AdminExpenses /></ProtectedRoute>} />
+            <Route path="/admin/tracking/report" element={<ProtectedRoute requiredRole="admin"><AdminTrackingReport /></ProtectedRoute>} />
             <Route path="/admin/reports" element={<ProtectedRoute requiredRole="admin"><Reports /></ProtectedRoute>} />
             <Route path="/admin/reports/warehouse" element={<ProtectedRoute requiredRole="admin"><ReportsWarehouse /></ProtectedRoute>} />
             <Route path="/admin/reports/branches" element={<ProtectedRoute requiredRole="admin"><ReportsBranches /></ProtectedRoute>} />

--- a/src/pages/admin/tracking/Expenses.tsx
+++ b/src/pages/admin/tracking/Expenses.tsx
@@ -1,0 +1,372 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/hooks/use-toast';
+import { apiService } from '@/utils/api';
+
+const moneyFormatter = new Intl.NumberFormat('ru-RU', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+interface BranchOption {
+  label: string;
+  value: string;
+}
+
+interface ExpenseRow {
+  id: string;
+  title: string;
+  description: string | null;
+  branch_id: string | null;
+  amount: number;
+  date: string;
+}
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+const Expenses: React.FC = () => {
+  const [branchOptions, setBranchOptions] = useState<BranchOption[]>([
+    { label: 'Главный склад', value: 'warehouse' },
+  ]);
+  const [entries, setEntries] = useState<ExpenseRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    branch_id: 'warehouse',
+    amount: '',
+    date: todayIso(),
+  });
+  const [filters, setFilters] = useState({
+    date_from: '',
+    date_to: '',
+    branch_id: '',
+  });
+
+  const branchLabelMap = useMemo(() => {
+    const map: Record<string, string> = { warehouse: 'Главный склад' };
+    branchOptions.forEach((option) => {
+      map[option.value] = option.label;
+    });
+    return map;
+  }, [branchOptions]);
+
+  useEffect(() => {
+    void fetchBranches();
+  }, []);
+
+  const loadEntries = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiService.getExpenses({
+        date_from: filters.date_from || undefined,
+        date_to: filters.date_to || undefined,
+        branch_id: filters.branch_id || undefined,
+      });
+      if (res.error) {
+        toast({
+          title: 'Ошибка',
+          description: res.error,
+          variant: 'destructive',
+        });
+        setEntries([]);
+        return;
+      }
+      const data = (res.data as any)?.data ?? [];
+      setEntries(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось загрузить расходы',
+        variant: 'destructive',
+      });
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [filters.branch_id, filters.date_from, filters.date_to]);
+
+  useEffect(() => {
+    void loadEntries();
+  }, [loadEntries]);
+
+  const fetchBranches = async () => {
+    try {
+      const res = await apiService.getBranches();
+      const list = Array.isArray(res.data)
+        ? res.data
+        : Array.isArray((res.data as any)?.data)
+        ? (res.data as any).data
+        : [];
+      const options = [
+        { label: 'Главный склад', value: 'warehouse' },
+        ...list.map((branch: any) => ({ label: branch.name, value: branch.id })),
+      ];
+      setBranchOptions(options);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось загрузить список филиалов',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!form.title.trim()) {
+      toast({
+        title: 'Ошибка',
+        description: 'Введите название расхода',
+        variant: 'destructive',
+      });
+      return;
+    }
+    const amountValue = Number(form.amount);
+    if (!Number.isFinite(amountValue) || amountValue <= 0) {
+      toast({
+        title: 'Ошибка',
+        description: 'Сумма должна быть больше нуля',
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (!form.date) {
+      toast({
+        title: 'Ошибка',
+        description: 'Выберите дату расхода',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await apiService.createExpense({
+        title: form.title.trim(),
+        description: form.description.trim() ? form.description.trim() : undefined,
+        branch_id: form.branch_id || undefined,
+        amount: amountValue,
+        date: form.date,
+      });
+      if (res.error) {
+        toast({
+          title: 'Ошибка',
+          description: res.error,
+          variant: 'destructive',
+        });
+        return;
+      }
+      toast({ title: 'Успех', description: 'Расход добавлен' });
+      setForm((prev) => ({
+        ...prev,
+        title: '',
+        description: '',
+        amount: '',
+      }));
+      await loadEntries();
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось сохранить расход',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const branchLabel = (id: string | null | undefined) => {
+    if (!id) return branchLabelMap['warehouse'] ?? 'Главный склад';
+    return branchLabelMap[id] ?? '—';
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Расходы</h1>
+        <p className="text-gray-600 mt-2">
+          Фиксируйте расходы и контролируйте затраты по каждому филиалу.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Добавить расход</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <div className="md:col-span-2 lg:col-span-1">
+                <Label htmlFor="title">Название</Label>
+                <Input
+                  id="title"
+                  value={form.title}
+                  onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+                  placeholder="Например, аренда офиса"
+                />
+              </div>
+              <div>
+                <Label>Филиал</Label>
+                <Select
+                  value={form.branch_id}
+                  onValueChange={(value) => setForm((prev) => ({ ...prev, branch_id: value }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Выберите филиал" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {branchOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="amount">Сумма</Label>
+                <Input
+                  id="amount"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={form.amount}
+                  onChange={(event) => setForm((prev) => ({ ...prev, amount: event.target.value }))}
+                  placeholder="0,00"
+                />
+              </div>
+              <div>
+                <Label htmlFor="date">Дата</Label>
+                <Input
+                  id="date"
+                  type="date"
+                  value={form.date}
+                  onChange={(event) => setForm((prev) => ({ ...prev, date: event.target.value }))}
+                />
+              </div>
+              <div className="md:col-span-2 lg:col-span-3">
+                <Label htmlFor="description">Описание</Label>
+                <Textarea
+                  id="description"
+                  value={form.description}
+                  onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+                  placeholder="Дополнительные детали (необязательно)"
+                  rows={3}
+                />
+              </div>
+            </div>
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Сохранение…' : 'Добавить расход'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>История расходов</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div>
+              <Label htmlFor="filter_date_from">Дата с</Label>
+              <Input
+                id="filter_date_from"
+                type="date"
+                value={filters.date_from}
+                onChange={(event) =>
+                  setFilters((prev) => ({ ...prev, date_from: event.target.value }))
+                }
+              />
+            </div>
+            <div>
+              <Label htmlFor="filter_date_to">Дата по</Label>
+              <Input
+                id="filter_date_to"
+                type="date"
+                value={filters.date_to}
+                onChange={(event) =>
+                  setFilters((prev) => ({ ...prev, date_to: event.target.value }))
+                }
+              />
+            </div>
+            <div>
+              <Label>Филиал</Label>
+              <Select
+                value={filters.branch_id}
+                onValueChange={(value) =>
+                  setFilters((prev) => ({ ...prev, branch_id: value }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Все филиалы" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Все филиалы</SelectItem>
+                  {branchOptions.map((option) => (
+                    <SelectItem key={`filter-${option.value}`} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="py-10 text-center text-gray-500">Загрузка…</div>
+          ) : entries.length === 0 ? (
+            <div className="py-10 text-center text-gray-500">Нет расходов за выбранный период</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="bg-muted">
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Дата</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Название</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Описание</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Филиал</th>
+                    <th className="text-right px-4 py-2 font-medium text-gray-700">Сумма</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {entries.map((entry) => (
+                    <tr key={entry.id} className="border-t">
+                      <td className="px-4 py-2 whitespace-nowrap">{entry.date}</td>
+                      <td className="px-4 py-2 whitespace-nowrap">{entry.title}</td>
+                      <td className="px-4 py-2">
+                        {entry.description ? entry.description : '—'}
+                      </td>
+                      <td className="px-4 py-2 whitespace-nowrap">{branchLabel(entry.branch_id)}</td>
+                      <td className="px-4 py-2 text-right whitespace-nowrap">
+                        {moneyFormatter.format(entry.amount ?? 0)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Expenses;

--- a/src/pages/admin/tracking/Payroll.tsx
+++ b/src/pages/admin/tracking/Payroll.tsx
@@ -1,0 +1,384 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from '@/hooks/use-toast';
+import { apiService } from '@/utils/api';
+
+const moneyFormatter = new Intl.NumberFormat('ru-RU', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+interface BranchOption {
+  label: string;
+  value: string;
+}
+
+interface PayrollRow {
+  id: string;
+  first_name: string;
+  last_name: string;
+  role: string;
+  branch_id: string | null;
+  amount: number;
+  date: string;
+}
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+const Payroll: React.FC = () => {
+  const [branchOptions, setBranchOptions] = useState<BranchOption[]>([
+    { label: 'Главный склад', value: 'warehouse' },
+  ]);
+  const [entries, setEntries] = useState<PayrollRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({
+    first_name: '',
+    last_name: '',
+    role: '',
+    branch_id: 'warehouse',
+    amount: '',
+    date: todayIso(),
+  });
+  const [filters, setFilters] = useState({
+    date_from: '',
+    date_to: '',
+    branch_id: '',
+  });
+
+  const branchLabelMap = useMemo(() => {
+    const map: Record<string, string> = { warehouse: 'Главный склад' };
+    branchOptions.forEach((option) => {
+      map[option.value] = option.label;
+    });
+    return map;
+  }, [branchOptions]);
+
+  useEffect(() => {
+    void fetchBranches();
+  }, []);
+
+  const loadEntries = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await apiService.getPayroll({
+        date_from: filters.date_from || undefined,
+        date_to: filters.date_to || undefined,
+        branch_id: filters.branch_id || undefined,
+      });
+      if (res.error) {
+        toast({
+          title: 'Ошибка',
+          description: res.error,
+          variant: 'destructive',
+        });
+        setEntries([]);
+        return;
+      }
+      const data = (res.data as any)?.data ?? [];
+      setEntries(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось загрузить записи',
+        variant: 'destructive',
+      });
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [filters.branch_id, filters.date_from, filters.date_to]);
+
+  useEffect(() => {
+    void loadEntries();
+  }, [loadEntries]);
+
+  const fetchBranches = async () => {
+    try {
+      const res = await apiService.getBranches();
+      const list = Array.isArray(res.data)
+        ? res.data
+        : Array.isArray((res.data as any)?.data)
+        ? (res.data as any).data
+        : [];
+      const options = [
+        { label: 'Главный склад', value: 'warehouse' },
+        ...list.map((branch: any) => ({ label: branch.name, value: branch.id })),
+      ];
+      setBranchOptions(options);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось загрузить список филиалов',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!form.first_name.trim() || !form.last_name.trim() || !form.role.trim()) {
+      toast({
+        title: 'Ошибка',
+        description: 'Заполните имя, фамилию и должность',
+        variant: 'destructive',
+      });
+      return;
+    }
+    const amountValue = Number(form.amount);
+    if (!Number.isFinite(amountValue) || amountValue <= 0) {
+      toast({
+        title: 'Ошибка',
+        description: 'Сумма должна быть больше нуля',
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (!form.date) {
+      toast({
+        title: 'Ошибка',
+        description: 'Выберите дату выплаты',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const payload = {
+        first_name: form.first_name.trim(),
+        last_name: form.last_name.trim(),
+        role: form.role.trim(),
+        branch_id: form.branch_id || undefined,
+        amount: amountValue,
+        date: form.date,
+      };
+      const res = await apiService.createPayroll(payload);
+      if (res.error) {
+        toast({
+          title: 'Ошибка',
+          description: res.error,
+          variant: 'destructive',
+        });
+        return;
+      }
+      toast({ title: 'Успех', description: 'Запись о зарплате добавлена' });
+      setForm((prev) => ({
+        ...prev,
+        first_name: '',
+        last_name: '',
+        role: '',
+        amount: '',
+      }));
+      await loadEntries();
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось сохранить запись',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const branchLabel = (id: string | null | undefined) => {
+    if (!id) return branchLabelMap['warehouse'] ?? 'Главный склад';
+    return branchLabelMap[id] ?? '—';
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Зарплата</h1>
+        <p className="text-gray-600 mt-2">
+          Добавляйте записи о начислении заработной платы и отслеживайте выплаты по филиалам.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Добавить запись</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <div>
+                <Label htmlFor="first_name">Имя</Label>
+                <Input
+                  id="first_name"
+                  value={form.first_name}
+                  onChange={(event) => setForm((prev) => ({ ...prev, first_name: event.target.value }))}
+                  placeholder="Имя сотрудника"
+                />
+              </div>
+              <div>
+                <Label htmlFor="last_name">Фамилия</Label>
+                <Input
+                  id="last_name"
+                  value={form.last_name}
+                  onChange={(event) => setForm((prev) => ({ ...prev, last_name: event.target.value }))}
+                  placeholder="Фамилия сотрудника"
+                />
+              </div>
+              <div>
+                <Label htmlFor="role">Роль</Label>
+                <Input
+                  id="role"
+                  value={form.role}
+                  onChange={(event) => setForm((prev) => ({ ...prev, role: event.target.value }))}
+                  placeholder="Должность"
+                />
+              </div>
+              <div>
+                <Label>Филиал</Label>
+                <Select
+                  value={form.branch_id}
+                  onValueChange={(value) => setForm((prev) => ({ ...prev, branch_id: value }))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Выберите филиал" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {branchOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="amount">Сумма</Label>
+                <Input
+                  id="amount"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={form.amount}
+                  onChange={(event) => setForm((prev) => ({ ...prev, amount: event.target.value }))}
+                  placeholder="0,00"
+                />
+              </div>
+              <div>
+                <Label htmlFor="date">Дата</Label>
+                <Input
+                  id="date"
+                  type="date"
+                  value={form.date}
+                  onChange={(event) => setForm((prev) => ({ ...prev, date: event.target.value }))}
+                />
+              </div>
+            </div>
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Сохранение…' : 'Добавить запись'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>История выплат</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div>
+              <Label htmlFor="filter_date_from">Дата с</Label>
+              <Input
+                id="filter_date_from"
+                type="date"
+                value={filters.date_from}
+                onChange={(event) =>
+                  setFilters((prev) => ({ ...prev, date_from: event.target.value }))
+                }
+              />
+            </div>
+            <div>
+              <Label htmlFor="filter_date_to">Дата по</Label>
+              <Input
+                id="filter_date_to"
+                type="date"
+                value={filters.date_to}
+                onChange={(event) =>
+                  setFilters((prev) => ({ ...prev, date_to: event.target.value }))
+                }
+              />
+            </div>
+            <div>
+              <Label>Филиал</Label>
+              <Select
+                value={filters.branch_id}
+                onValueChange={(value) =>
+                  setFilters((prev) => ({ ...prev, branch_id: value }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Все филиалы" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Все филиалы</SelectItem>
+                  {branchOptions.map((option) => (
+                    <SelectItem key={`filter-${option.value}`} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="py-10 text-center text-gray-500">Загрузка…</div>
+          ) : entries.length === 0 ? (
+            <div className="py-10 text-center text-gray-500">Нет записей за выбранный период</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="bg-muted">
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Дата</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Сотрудник</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Роль</th>
+                    <th className="text-left px-4 py-2 font-medium text-gray-700">Филиал</th>
+                    <th className="text-right px-4 py-2 font-medium text-gray-700">Сумма</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {entries.map((entry) => (
+                    <tr key={entry.id} className="border-t">
+                      <td className="px-4 py-2 whitespace-nowrap">{entry.date}</td>
+                      <td className="px-4 py-2 whitespace-nowrap">
+                        {entry.last_name} {entry.first_name}
+                      </td>
+                      <td className="px-4 py-2 whitespace-nowrap">{entry.role}</td>
+                      <td className="px-4 py-2 whitespace-nowrap">{branchLabel(entry.branch_id)}</td>
+                      <td className="px-4 py-2 text-right whitespace-nowrap">
+                        {moneyFormatter.format(entry.amount ?? 0)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Payroll;

--- a/src/pages/admin/tracking/Report.tsx
+++ b/src/pages/admin/tracking/Report.tsx
@@ -1,0 +1,295 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from '@/hooks/use-toast';
+import { apiService } from '@/utils/api';
+
+interface BranchOption {
+  label: string;
+  value: string;
+}
+
+interface TrackingReportResult {
+  period: { from: string; to: string };
+  branch_id: string | null;
+  kind: 'payroll' | 'expenses' | 'combined';
+  payroll_sum: number;
+  expenses_sum: number;
+  sent_value: number;
+  total: number;
+}
+
+const moneyFormatter = new Intl.NumberFormat('ru-RU', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+const Report: React.FC = () => {
+  const [branchOptions, setBranchOptions] = useState<BranchOption[]>([
+    { label: 'Главный склад', value: 'warehouse' },
+  ]);
+  const [form, setForm] = useState({
+    date_from: todayIso(),
+    date_to: todayIso(),
+    branch_id: 'warehouse',
+    kind: 'combined' as 'payroll' | 'expenses' | 'combined',
+  });
+  const [loading, setLoading] = useState(false);
+  const [report, setReport] = useState<TrackingReportResult | null>(null);
+
+  const branchLabelMap = useMemo(() => {
+    const map: Record<string, string> = { warehouse: 'Главный склад' };
+    branchOptions.forEach((option) => {
+      map[option.value] = option.label;
+    });
+    return map;
+  }, [branchOptions]);
+
+  useEffect(() => {
+    void fetchBranches();
+  }, []);
+
+  const fetchBranches = async () => {
+    try {
+      const res = await apiService.getBranches();
+      const list = Array.isArray(res.data)
+        ? res.data
+        : Array.isArray((res.data as any)?.data)
+        ? (res.data as any).data
+        : [];
+      const options = [
+        { label: 'Главный склад', value: 'warehouse' },
+        ...list.map((branch: any) => ({ label: branch.name, value: branch.id })),
+      ];
+      setBranchOptions(options);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось загрузить список филиалов',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleGenerate = async () => {
+    if (!form.date_from || !form.date_to) {
+      toast({
+        title: 'Ошибка',
+        description: 'Выберите период отчёта',
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (form.date_from > form.date_to) {
+      toast({
+        title: 'Ошибка',
+        description: 'Дата начала не может быть позже даты окончания',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await apiService.getTrackingReport({
+        date_from: form.date_from,
+        date_to: form.date_to,
+        branch_id: form.branch_id,
+        kind: form.kind,
+      });
+      if (res.error) {
+        toast({
+          title: 'Ошибка',
+          description: res.error,
+          variant: 'destructive',
+        });
+        setReport(null);
+        return;
+      }
+      const data = res.data as TrackingReportResult | undefined;
+      if (!data) {
+        toast({
+          title: 'Ошибка',
+          description: 'Не удалось получить данные отчёта',
+          variant: 'destructive',
+        });
+        setReport(null);
+        return;
+      }
+      setReport(data);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось сформировать отчёт',
+        variant: 'destructive',
+      });
+      setReport(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const branchLabel = (id: string | null | undefined) => {
+    if (!id || id === 'warehouse') {
+      return branchLabelMap['warehouse'] ?? 'Главный склад';
+    }
+    return branchLabelMap[id] ?? '—';
+  };
+
+  const kindLabel = (kind: 'payroll' | 'expenses' | 'combined') => {
+    switch (kind) {
+      case 'payroll':
+        return 'По зарплатам';
+      case 'expenses':
+        return 'По расходам';
+      default:
+        return 'Общий отчёт';
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Отчёт</h1>
+        <p className="text-gray-600 mt-2">
+          Сформируйте отчёт по зарплатам и расходам за выбранный период и филиал.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Параметры отчёта</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div>
+              <Label htmlFor="date_from">Дата с</Label>
+              <Input
+                id="date_from"
+                type="date"
+                value={form.date_from}
+                onChange={(event) => setForm((prev) => ({ ...prev, date_from: event.target.value }))}
+              />
+            </div>
+            <div>
+              <Label htmlFor="date_to">Дата по</Label>
+              <Input
+                id="date_to"
+                type="date"
+                value={form.date_to}
+                onChange={(event) => setForm((prev) => ({ ...prev, date_to: event.target.value }))}
+              />
+            </div>
+            <div>
+              <Label>Филиал</Label>
+              <Select
+                value={form.branch_id}
+                onValueChange={(value) => setForm((prev) => ({ ...prev, branch_id: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Выберите филиал" />
+                </SelectTrigger>
+                <SelectContent>
+                  {branchOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Тип отчёта</Label>
+              <Select
+                value={form.kind}
+                onValueChange={(value) =>
+                  setForm((prev) => ({ ...prev, kind: value as 'payroll' | 'expenses' | 'combined' }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Выберите тип" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="combined">Общий</SelectItem>
+                  <SelectItem value="payroll">По зарплатам</SelectItem>
+                  <SelectItem value="expenses">По расходам</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <Button onClick={handleGenerate} disabled={loading}>
+            {loading ? 'Формирование…' : 'Сгенерировать отчёт'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {report && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Результаты</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="rounded-lg border p-4">
+                <p className="text-sm text-gray-500">Период</p>
+                <p className="text-lg font-semibold">
+                  {report.period.from} — {report.period.to}
+                </p>
+              </div>
+              <div className="rounded-lg border p-4">
+                <p className="text-sm text-gray-500">Филиал</p>
+                <p className="text-lg font-semibold">{branchLabel(report.branch_id)}</p>
+              </div>
+              <div className="rounded-lg border p-4">
+                <p className="text-sm text-gray-500">Тип отчёта</p>
+                <p className="text-lg font-semibold">{kindLabel(report.kind)}</p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="rounded-lg border p-4">
+                <p className="text-sm text-gray-500">Итог по зарплатам</p>
+                <p className="text-2xl font-semibold">
+                  {moneyFormatter.format(report.payroll_sum ?? 0)} ₸
+                </p>
+              </div>
+              <div className="rounded-lg border p-4">
+                <p className="text-sm text-gray-500">Итог по расходам</p>
+                <p className="text-2xl font-semibold">
+                  {moneyFormatter.format(report.expenses_sum ?? 0)} ₸
+                </p>
+              </div>
+              <div className="rounded-lg border p-4">
+                <p className="text-sm text-gray-500">Стоимость отправленных товаров</p>
+                <p className="text-2xl font-semibold">
+                  {moneyFormatter.format(report.sent_value ?? 0)} ₸
+                </p>
+              </div>
+              <div className="rounded-lg border p-4 bg-blue-50 border-blue-200">
+                <p className="text-sm text-blue-700">Итого</p>
+                <p className="text-2xl font-semibold text-blue-800">
+                  {moneyFormatter.format(report.total ?? 0)} ₸
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default Report;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -747,6 +747,72 @@ class ApiService {
     return { data: this.normalizeData(res) };
   }
 
+  // Tracking: payroll
+  async getPayroll(params: { date_from?: string; date_to?: string; branch_id?: string } = {}) {
+    const qs = new URLSearchParams();
+    if (params.date_from) qs.set('date_from', params.date_from);
+    if (params.date_to) qs.set('date_to', params.date_to);
+    if (params.branch_id) qs.set('branch_id', params.branch_id);
+    const query = qs.toString();
+    const suffix = query ? `?${query}` : '';
+    return this.request<{ data: any[] }>(`/admin/tracking/payroll${suffix}`);
+  }
+
+  async createPayroll(body: {
+    first_name: string;
+    last_name: string;
+    role: string;
+    branch_id?: string | null;
+    amount: number;
+    date: string;
+  }) {
+    return this.request('/admin/tracking/payroll', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+
+  // Tracking: expenses
+  async getExpenses(params: { date_from?: string; date_to?: string; branch_id?: string } = {}) {
+    const qs = new URLSearchParams();
+    if (params.date_from) qs.set('date_from', params.date_from);
+    if (params.date_to) qs.set('date_to', params.date_to);
+    if (params.branch_id) qs.set('branch_id', params.branch_id);
+    const query = qs.toString();
+    const suffix = query ? `?${query}` : '';
+    return this.request<{ data: any[] }>(`/admin/tracking/expenses${suffix}`);
+  }
+
+  async createExpense(body: {
+    title: string;
+    description?: string;
+    branch_id?: string | null;
+    amount: number;
+    date: string;
+  }) {
+    return this.request('/admin/tracking/expenses', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+
+  // Tracking: report
+  async getTrackingReport(params: {
+    date_from: string;
+    date_to: string;
+    branch_id?: string;
+    kind?: 'payroll' | 'expenses' | 'combined';
+  }) {
+    const qs = new URLSearchParams();
+    qs.set('date_from', params.date_from);
+    qs.set('date_to', params.date_to);
+    if (params.branch_id) qs.set('branch_id', params.branch_id);
+    if (params.kind) qs.set('kind', params.kind);
+    const query = qs.toString();
+    const suffix = query ? `?${query}` : '';
+    return this.request(`/admin/tracking/report${suffix}`);
+  }
+
   // Mark calendar event as dispensed
   async markDispensedOnCalendar(patientId: string, dateISO: string) {
     return this.request<any>('/calendar/mark-dispensed', {


### PR DESCRIPTION
## Summary
- add payroll and expense tracking models plus admin APIs for listing, creation, and combined reporting
- expose tracking helpers in the frontend API client and route the new admin pages
- build UI for payroll entry, expenses entry, and period summary reporting with grouped sidebar navigation

## Testing
- `npm run lint` *(fails: repository already contains numerous lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e62d951c8328b811154087f15fbd