### PR TITLE
Fix arrivals report handling for branch filters

### DIFF
--- a/src/pages/branch/BranchReports.tsx
+++ b/src/pages/branch/BranchReports.tsx
@@ -76,11 +76,15 @@ const BranchReports: React.FC = () => {
           });
           break;
         case 'arrivals':
-          response = await apiService.getArrivalsReport({
-            branch_id: branchId,
-            date_from: dateFrom || undefined,
-            date_to: dateTo || undefined,
-          });
+          if (!dateFrom && !dateTo) {
+            response = await apiService.getArrivalsReport({ branch_id: branchId });
+          } else {
+            response = await apiService.getArrivalsReport({
+              branch_id: branchId,
+              date_from: dateFrom || undefined,
+              date_to: dateTo || undefined,
+            });
+          }
           break;
         default:
           throw new Error('Unknown report type');
@@ -132,11 +136,15 @@ const BranchReports: React.FC = () => {
       }
 
       if (selectedReportType === 'arrivals') {
-        await apiService.exportArrivalsExcel({
-          branch_id: branchId,
-          date_from: dateFrom || undefined,
-          date_to: dateTo || undefined,
-        });
+        if (!dateFrom && !dateTo) {
+          await apiService.exportArrivalsExcel({ branch_id: branchId });
+        } else {
+          await apiService.exportArrivalsExcel({
+            branch_id: branchId,
+            date_from: dateFrom || undefined,
+            date_to: dateTo || undefined,
+          });
+        }
         toast({ title: 'Отчет экспортирован в Excel' });
         return;
       }


### PR DESCRIPTION
## Summary
- implement safe main branch detection and optional period filtering for the arrivals report, including updated Excel export naming
- ensure the frontend omits empty date parameters for arrivals reports and updates the Excel download flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ecb7b5090083288008fede871872ab